### PR TITLE
feat: add workspace management commands

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1341,6 +1341,7 @@ async fn derive_config_from_params(
         review_model: None,
         config_profile: profile,
         cwd: cwd.map(PathBuf::from),
+        workspaces: None,
         approval_policy,
         sandbox_mode,
         model_provider: None,

--- a/codex-rs/app-server/src/fuzzy_file_search.rs
+++ b/codex-rs/app-server/src/fuzzy_file_search.rs
@@ -46,6 +46,7 @@ pub(crate) async fn run_fuzzy_file_search(
                 threads,
                 cancel_flag,
                 COMPUTE_INDICES,
+                file_search::FileTypeFilter::FilesOnly,
             ) {
                 Ok(res) => Ok((root, res)),
                 Err(err) => Err((root, err)),

--- a/codex-rs/core/src/rollout/list.rs
+++ b/codex-rs/core/src/rollout/list.rs
@@ -515,6 +515,7 @@ pub async fn find_conversation_path_by_id_str(
         threads,
         cancel,
         compute_indices,
+        file_search::FileTypeFilter::FilesOnly,
     )
     .map_err(|e| io::Error::other(format!("file search failed: {e}")))?;
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -173,6 +173,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         approval_policy: Some(AskForApproval::Never),
         sandbox_mode,
         cwd: cwd.map(|p| p.canonicalize().unwrap_or(p)),
+        workspaces: None,
         model_provider,
         codex_linux_sandbox_exe,
         base_instructions: None,

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -154,6 +154,7 @@ impl CodexToolCallParam {
             review_model: None,
             config_profile: profile,
             cwd: cwd.map(PathBuf::from),
+            workspaces: None,
             approval_policy: approval_policy.map(Into::into),
             sandbox_mode: sandbox.map(Into::into),
             model_provider: None,

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -30,7 +30,10 @@ pub(crate) enum AppEvent {
     /// Kick off an asynchronous file search for the given query (text after
     /// the `@`). Previous searches may be cancelled by the app layer so there
     /// is at most one in-flight search.
-    StartFileSearch(String),
+    StartFileSearch {
+        query: String,
+        file_type_filter: codex_file_search::FileTypeFilter,
+    },
 
     /// Result of a completed asynchronous file search. The `query` echoes the
     /// original search term so the UI can decide whether the results are
@@ -87,4 +90,10 @@ pub(crate) enum AppEvent {
 
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
+
+    /// Add a directory to the workspace.
+    AddDirectory(PathBuf),
+
+    /// Remove a directory from the workspace.
+    RemoveDirectory(PathBuf),
 }

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -162,7 +162,12 @@ impl CommandPopup {
             .map(|(item, indices, _)| {
                 let (name, description) = match item {
                     CommandItem::Builtin(cmd) => {
-                        (format!("/{}", cmd.command()), cmd.description().to_string())
+                        let name = if let Some(hint) = cmd.parameter_hint() {
+                            format!("/{} {}", cmd.command(), hint)
+                        } else {
+                            format!("/{}", cmd.command())
+                        };
+                        (name, cmd.description().to_string())
                     }
                     CommandItem::UserPrompt(i) => (
                         format!("/{PROMPTS_CMD_PREFIX}:{}", self.prompts[i].name),

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -381,6 +381,11 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    /// Update workspace paths for autocomplete in /remove-workspace.
+    pub(crate) fn set_workspaces(&mut self, workspaces: Vec<PathBuf>, cwd: PathBuf) {
+        self.composer.set_workspaces(workspaces, cwd);
+    }
+
     pub(crate) fn composer_is_empty(&self) -> bool {
         self.composer.is_empty()
     }

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -68,6 +68,10 @@ pub struct Cli {
     #[clap(long = "cd", short = 'C', value_name = "DIR")]
     pub cwd: Option<PathBuf>,
 
+    /// Add additional workspace directories for the agent to access.
+    #[arg(long = "add-dir", value_name = "DIR", value_delimiter = ',', num_args = 1..)]
+    pub workspaces: Vec<PathBuf>,
+
     /// Enable web search (off by default). When enabled, the native Responses `web_search` tool is available to the model (no per‑call approval).
     #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -133,12 +133,19 @@ pub async fn run_main(
     // canonicalize the cwd
     let cwd = cli.cwd.clone().map(|p| p.canonicalize().unwrap_or(p));
 
+    let workspaces = if cli.workspaces.is_empty() {
+        None
+    } else {
+        Some(cli.workspaces.clone())
+    };
+
     let overrides = ConfigOverrides {
         model,
         review_model: None,
         approval_policy,
         sandbox_mode,
         cwd,
+        workspaces,
         model_provider: model_provider_override,
         config_profile: cli.config_profile.clone(),
         codex_linux_sandbox_exe,

--- a/codex-rs/tui/src/session_log.rs
+++ b/codex-rs/tui/src/session_log.rs
@@ -145,12 +145,16 @@ pub(crate) fn log_inbound_app_event(event: &AppEvent) {
             });
             LOGGER.write_json_line(value);
         }
-        AppEvent::StartFileSearch(query) => {
+        AppEvent::StartFileSearch {
+            query,
+            file_type_filter,
+        } => {
             let value = json!({
                 "ts": now_ts(),
                 "dir": "to_tui",
                 "kind": "file_search_start",
                 "query": query,
+                "file_type_filter": format!("{:?}", file_type_filter),
             });
             LOGGER.write_json_line(value);
         }

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -23,6 +23,8 @@ pub enum SlashCommand {
     Mention,
     Status,
     Mcp,
+    AddWorkspace,
+    RemoveWorkspace,
     Logout,
     Quit,
     #[cfg(debug_assertions)]
@@ -45,6 +47,8 @@ impl SlashCommand {
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
             SlashCommand::Mcp => "list configured MCP tools",
+            SlashCommand::AddWorkspace => "add a workspace directory",
+            SlashCommand::RemoveWorkspace => "remove a workspace directory",
             SlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]
             SlashCommand::TestApproval => "test approval request",
@@ -55,6 +59,15 @@ impl SlashCommand {
     /// existing code that expects a method named `command()`.
     pub fn command(self) -> &'static str {
         self.into()
+    }
+
+    /// Returns parameter hint for commands that take arguments.
+    pub fn parameter_hint(self) -> Option<&'static str> {
+        match self {
+            SlashCommand::AddWorkspace => Some("<path>"),
+            SlashCommand::RemoveWorkspace => Some("<path>"),
+            _ => None,
+        }
     }
 
     /// Whether this command can be run while a task is in progress.
@@ -72,6 +85,8 @@ impl SlashCommand {
             | SlashCommand::Mention
             | SlashCommand::Status
             | SlashCommand::Mcp
+            | SlashCommand::AddWorkspace
+            | SlashCommand::RemoveWorkspace
             | SlashCommand::Quit => true,
 
             #[cfg(debug_assertions)]


### PR DESCRIPTION
## Summary
- plumb workspace directories from config/CLI into the TUI
- add slash commands and directory-aware search to manage workspaces

## Testing
- cargo test -p codex-file-search
- cargo test -p codex-tui
- cargo test -p codex-core (unit: serialize_environment_context_includes_workspaces)
- cargo test -p codex-app-server (fails in sandbox: wiremock cannot bind ports)