### PR TITLE
Add usage status alerts to TUI footer

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -87,4 +87,7 @@ pub(crate) enum AppEvent {
 
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
+
+    /// Update the usage status bar with new rate limit data.
+    UpdateRateLimits(Option<crate::status::RateLimitSnapshotDisplay>),
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use crate::app_event_sender::AppEventSender;
 use crate::tui::FrameRequester;
+use crate::usage_status_bar::UsageStatusText;
 use bottom_pane_view::BottomPaneView;
 use codex_file_search::FileMatch;
 use crossterm::event::KeyCode;
@@ -69,6 +70,7 @@ pub(crate) struct BottomPane {
     /// Queued user messages to show under the status indicator.
     queued_user_messages: Vec<String>,
     context_window_percent: Option<u8>,
+    usage_status: Option<UsageStatusText>,
 }
 
 pub(crate) struct BottomPaneParams {
@@ -102,6 +104,7 @@ impl BottomPane {
             queued_user_messages: Vec::new(),
             esc_backtrack_hint: false,
             context_window_percent: None,
+            usage_status: None,
         }
     }
 
@@ -357,6 +360,16 @@ impl BottomPane {
 
         self.context_window_percent = percent;
         self.composer.set_context_window_percent(percent);
+        self.request_redraw();
+    }
+
+    pub(crate) fn set_usage_status(&mut self, status: Option<UsageStatusText>) {
+        if self.usage_status == status {
+            return;
+        }
+
+        self.usage_status = status.clone();
+        self.composer.set_usage_status(status);
         self.request_redraw();
     }
 

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_empty_with_usage_status_red.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_empty_with_usage_status_red.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/bottom_pane/footer.rs
+expression: terminal.backend()
+---
+"                                           weekly limit reached (resets in 2h)  "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_empty_with_usage_status_yellow.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_empty_with_usage_status_yellow.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/bottom_pane/footer.rs
+expression: terminal.backend()
+---
+"                                            95% of weekly limit (resets in 2h)  "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_with_usage_status_red.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_with_usage_status_red.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/bottom_pane/footer.rs
+expression: terminal.backend()
+---
+"  ? for shortcuts                                limit reached (resets in 30m)  "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_with_usage_status_yellow.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_with_usage_status_yellow.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/bottom_pane/footer.rs
+expression: terminal.backend()
+---
+"  ? for shortcuts                                 85% of limit (resets in 30m)  "

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -70,6 +70,7 @@ mod terminal_palette;
 mod text_formatting;
 mod tui;
 mod ui_consts;
+mod usage_status_bar;
 mod version;
 mod wrapping;
 

--- a/codex-rs/tui/src/status/mod.rs
+++ b/codex-rs/tui/src/status/mod.rs
@@ -9,4 +9,7 @@ pub(crate) use rate_limits::RateLimitSnapshotDisplay;
 pub(crate) use rate_limits::rate_limit_snapshot_display;
 
 #[cfg(test)]
+pub(crate) use rate_limits::RateLimitWindowDisplay;
+
+#[cfg(test)]
 mod tests;

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -4,16 +4,16 @@ expression: sanitized
 ---
 /status
 
-╭────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                                  │
-│                                                                            │
-│  Model:            gpt-5-codex (reasoning none, summaries auto)            │
-│  Directory: [[workspace]]                                                  │
-│  Approval:         on-request                                              │
-│  Sandbox:          read-only                                               │
-│  Agents.md:        <none>                                                  │
-│                                                                            │
-│  Token usage:      1.2K total  (800 input + 400 output)                    │
-│  Context window:   100% left (1.2K used / 272K)                            │
-│  Monthly limit:    [██░░░░░░░░░░░░░░░░░░] 12% used (resets 07:08 on 7 May) │
-╰────────────────────────────────────────────────────────────────────────────╯
+╭───────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                         │
+│                                                                   │
+│  Model:            gpt-5-codex (reasoning none, summaries auto)   │
+│  Directory: [[workspace]]                                         │
+│  Approval:         on-request                                     │
+│  Sandbox:          read-only                                      │
+│  Agents.md:        <none>                                         │
+│                                                                   │
+│  Token usage:      1.2K total  (800 input + 400 output)           │
+│  Context window:   100% left (1.2K used / 272K)                   │
+│  Monthly limit:    [██░░░░░░░░░░░░░░░░░░] 12% used (resets in 1d) │
+╰───────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -15,6 +15,6 @@ expression: sanitized
 │                                                                     │
 │  Token usage:      1.9K total  (1K input + 900 output)              │
 │  Context window:   100% left (2.1K used / 272K)                     │
-│  5h limit:         [███████████████░░░░░] 72% used (resets 03:14)   │
-│  Weekly limit:     [█████████░░░░░░░░░░░] 45% used (resets 03:24)   │
+│  5h limit:         [███████████████░░░░░] 72% used (resets in 10m)  │
+│  Weekly limit:     [█████████░░░░░░░░░░░] 45% used (resets in 20m)  │
 ╰─────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -16,5 +16,5 @@ expression: sanitized
 │  Token usage:      1.9K total  (1K input + │
 │  Context window:   100% left (2.1K used /  │
 │  5h limit:         [███████████████░░░░░]  │
-│                    (resets 03:14)          │
+│                    (resets in 10m)         │
 ╰────────────────────────────────────────────╯

--- a/codex-rs/tui/src/usage_status_bar/mod.rs
+++ b/codex-rs/tui/src/usage_status_bar/mod.rs
@@ -1,0 +1,565 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Widget;
+use ratatui::widgets::WidgetRef;
+
+use crate::chatwidget::get_limits_duration;
+use crate::status::RateLimitSnapshotDisplay;
+
+const THRESHOLD_PERCENT: f64 = 70.0;
+const SIGNIFICANT_CHANGE_THRESHOLD: f64 = 5.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UrgencyLevel {
+    Warning,
+    Elevated,
+    Critical,
+}
+
+impl UrgencyLevel {
+    fn from_percent(percent: f64) -> Self {
+        if percent >= 90.0 {
+            UrgencyLevel::Critical
+        } else if percent >= 80.0 {
+            UrgencyLevel::Elevated
+        } else {
+            UrgencyLevel::Warning
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            UrgencyLevel::Warning => "WARNING",
+            UrgencyLevel::Elevated => "ALERT",
+            UrgencyLevel::Critical => "CRITICAL",
+        }
+    }
+
+    fn color(self) -> ratatui::style::Color {
+        match self {
+            UrgencyLevel::Critical => ratatui::style::Color::Red,
+            UrgencyLevel::Warning | UrgencyLevel::Elevated => ratatui::style::Color::Yellow,
+        }
+    }
+}
+
+struct UrgentWindowInfo {
+    percent: f64,
+    reset_at: Option<String>,
+    window_label: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct UsageStatusText {
+    pub(crate) text: String,
+    pub(crate) at_limit: bool,
+}
+
+pub(crate) struct UsageStatusBar {
+    snapshot: Option<RateLimitSnapshotDisplay>,
+    dismissed: bool,
+}
+
+impl Default for UsageStatusBar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UsageStatusBar {
+    pub(crate) fn new() -> Self {
+        Self {
+            snapshot: None,
+            dismissed: false,
+        }
+    }
+
+    pub(crate) fn update_snapshot(&mut self, snapshot: Option<RateLimitSnapshotDisplay>) {
+        let should_reset_dismiss = match (&self.snapshot, &snapshot) {
+            (Some(old), Some(new)) => self.has_significant_change(old, new),
+            (None, Some(_)) => true,
+            _ => false,
+        };
+
+        self.snapshot = snapshot;
+        if should_reset_dismiss {
+            self.dismissed = false;
+        }
+    }
+
+    fn has_significant_change(
+        &self,
+        old: &RateLimitSnapshotDisplay,
+        new: &RateLimitSnapshotDisplay,
+    ) -> bool {
+        let old_max = self.max_percent_from_snapshot(old);
+        let new_max = self.max_percent_from_snapshot(new);
+
+        match (old_max, new_max) {
+            (Some(old_pct), Some(new_pct)) => {
+                (new_pct - old_pct).abs() >= SIGNIFICANT_CHANGE_THRESHOLD
+            }
+            (None, Some(_)) | (Some(_), None) => true,
+            (None, None) => false,
+        }
+    }
+
+    fn max_percent_from_snapshot(&self, snapshot: &RateLimitSnapshotDisplay) -> Option<f64> {
+        let primary_pct = snapshot.primary.as_ref().map(|w| w.used_percent);
+        let secondary_pct = snapshot.secondary.as_ref().map(|w| w.used_percent);
+
+        match (primary_pct, secondary_pct) {
+            (Some(p), Some(s)) => Some(p.max(s)),
+            (Some(p), None) => Some(p),
+            (None, Some(s)) => Some(s),
+            (None, None) => None,
+        }
+    }
+
+    pub(crate) fn dismiss(&mut self) {
+        self.dismissed = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_dismissed(&self) -> bool {
+        self.dismissed
+    }
+
+    pub(crate) fn should_show(&self) -> bool {
+        if self.dismissed {
+            return false;
+        }
+
+        let Some(snapshot) = &self.snapshot else {
+            return false;
+        };
+
+        let primary_exceeds = snapshot
+            .primary
+            .as_ref()
+            .is_some_and(|w| w.used_percent >= THRESHOLD_PERCENT);
+
+        let secondary_exceeds = snapshot
+            .secondary
+            .as_ref()
+            .is_some_and(|w| w.used_percent >= THRESHOLD_PERCENT);
+
+        primary_exceeds || secondary_exceeds
+    }
+
+    pub(crate) fn get_footer_text(&self) -> Option<UsageStatusText> {
+        if !self.should_show() {
+            return None;
+        }
+
+        let UrgentWindowInfo {
+            percent,
+            reset_at,
+            window_label,
+        } = self.get_urgent_window_info()?;
+
+        let reset_text = reset_at
+            .map(|r| format!(" (resets {r})"))
+            .unwrap_or_default();
+
+        let at_limit = percent >= 100.0;
+
+        let label_text = match window_label.as_str() {
+            "weekly" | "monthly" | "annual" => format!("{window_label} limit"),
+            _ => "limit".to_string(),
+        };
+
+        let text = if at_limit {
+            format!("{label_text} reached{reset_text}")
+        } else {
+            format!("{percent:.0}% of {label_text}{reset_text}")
+        };
+
+        Some(UsageStatusText { text, at_limit })
+    }
+
+    fn get_urgent_window_info(&self) -> Option<UrgentWindowInfo> {
+        let snapshot = self.snapshot.as_ref()?;
+
+        let primary_data = snapshot.primary.as_ref().and_then(|w| {
+            (w.used_percent >= THRESHOLD_PERCENT).then(|| {
+                let label = format_window_duration(w.window_minutes, "5h");
+                UrgentWindowInfo {
+                    percent: w.used_percent,
+                    reset_at: w.resets_at.clone(),
+                    window_label: label,
+                }
+            })
+        });
+
+        let secondary_data = snapshot.secondary.as_ref().and_then(|w| {
+            (w.used_percent >= THRESHOLD_PERCENT).then(|| {
+                let label = format_window_duration(w.window_minutes, "weekly");
+                UrgentWindowInfo {
+                    percent: w.used_percent,
+                    reset_at: w.resets_at.clone(),
+                    window_label: label,
+                }
+            })
+        });
+
+        match (primary_data, secondary_data) {
+            (Some(p), Some(s)) => Some(if p.percent >= s.percent { p } else { s }),
+            (Some(p), None) => Some(p),
+            (None, Some(s)) => Some(s),
+            (None, None) => None,
+        }
+    }
+}
+
+fn format_window_duration(window_minutes: Option<u64>, default: &str) -> String {
+    window_minutes
+        .map(get_limits_duration)
+        .unwrap_or_else(|| default.to_string())
+}
+
+impl WidgetRef for &UsageStatusBar {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        if !self.should_show() {
+            return;
+        }
+
+        let Some(info) = self.get_urgent_window_info() else {
+            return;
+        };
+
+        let urgency = UrgencyLevel::from_percent(info.percent);
+        let label = urgency.label();
+        let UrgentWindowInfo {
+            percent,
+            reset_at,
+            window_label,
+        } = info;
+
+        let mut text = format!("{label}: {percent:.0}% of {window_label} limit used");
+
+        if let Some(reset) = reset_at {
+            text.push_str(&format!(" (resets {reset})"));
+        }
+
+        text.push_str(" [Press Esc to dismiss]");
+
+        let line = Line::from(text).fg(urgency.color());
+
+        line.render(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::status::RateLimitWindowDisplay;
+
+    fn create_test_snapshot(
+        primary_percent: Option<f64>,
+        secondary_percent: Option<f64>,
+    ) -> RateLimitSnapshotDisplay {
+        RateLimitSnapshotDisplay {
+            primary: primary_percent.map(|used_percent| RateLimitWindowDisplay {
+                used_percent,
+                resets_at: Some("in 30m".to_string()),
+                window_minutes: Some(300),
+            }),
+            secondary: secondary_percent.map(|used_percent| RateLimitWindowDisplay {
+                used_percent,
+                resets_at: Some("in 2h".to_string()),
+                window_minutes: Some(10080),
+            }),
+        }
+    }
+
+    // Core visibility tests
+    #[test]
+    fn test_should_show_below_threshold() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(50.0), Some(60.0))));
+        assert!(!bar.should_show());
+    }
+
+    #[test]
+    fn test_should_show_above_threshold() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(75.0), Some(60.0))));
+        assert!(bar.should_show());
+    }
+
+    #[test]
+    fn test_should_show_dismissed() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(85.0), Some(75.0))));
+        assert!(bar.should_show());
+
+        bar.dismiss();
+        assert!(!bar.should_show());
+    }
+
+    // Window selection tests
+    #[test]
+    fn test_most_urgent_window_selects_highest() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(75.0), Some(85.0))));
+
+        let info = bar.get_urgent_window_info().unwrap();
+        assert_eq!(info.percent, 85.0);
+    }
+
+    #[test]
+    fn test_selects_secondary_when_higher() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(75.0), Some(95.0))));
+
+        let info = bar.get_urgent_window_info().unwrap();
+        assert_eq!(info.percent, 95.0);
+    }
+
+    // Dismiss behavior tests
+    #[test]
+    fn test_dismiss_resets_on_new_snapshot() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(80.0), None)));
+        bar.dismiss();
+        assert!(bar.is_dismissed());
+
+        bar.update_snapshot(Some(create_test_snapshot(Some(85.0), None)));
+        assert!(!bar.is_dismissed());
+    }
+
+    #[test]
+    fn test_dismiss_persists_on_insignificant_change() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(80.0), None)));
+        bar.dismiss();
+        assert!(bar.is_dismissed());
+
+        bar.update_snapshot(Some(create_test_snapshot(Some(82.0), None)));
+        assert!(bar.is_dismissed());
+    }
+
+    // Boundary value tests
+    #[test]
+    fn test_boundary_at_exactly_70_percent() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(70.0), None)));
+        assert!(bar.should_show());
+
+        bar.update_snapshot(Some(create_test_snapshot(Some(69.99), None)));
+        assert!(!bar.should_show());
+    }
+
+    #[test]
+    fn test_urgency_boundary_values() {
+        assert_eq!(UrgencyLevel::from_percent(69.9), UrgencyLevel::Warning);
+        assert_eq!(UrgencyLevel::from_percent(79.9), UrgencyLevel::Warning);
+        assert_eq!(UrgencyLevel::from_percent(80.0), UrgencyLevel::Elevated);
+        assert_eq!(UrgencyLevel::from_percent(89.9), UrgencyLevel::Elevated);
+        assert_eq!(UrgencyLevel::from_percent(90.0), UrgencyLevel::Critical);
+        assert_eq!(UrgencyLevel::from_percent(100.0), UrgencyLevel::Critical);
+    }
+
+    // Urgency level tests
+    #[test]
+    fn test_urgency_levels() {
+        assert_eq!(UrgencyLevel::from_percent(75.0), UrgencyLevel::Warning);
+        assert_eq!(UrgencyLevel::from_percent(85.0), UrgencyLevel::Elevated);
+        assert_eq!(UrgencyLevel::from_percent(95.0), UrgencyLevel::Critical);
+    }
+
+    #[test]
+    fn test_urgency_level_labels() {
+        assert_eq!(UrgencyLevel::Warning.label(), "WARNING");
+        assert_eq!(UrgencyLevel::Elevated.label(), "ALERT");
+        assert_eq!(UrgencyLevel::Critical.label(), "CRITICAL");
+    }
+
+    // Edge case tests
+    #[test]
+    fn test_both_windows_none() {
+        let mut bar = UsageStatusBar::new();
+        let snapshot = RateLimitSnapshotDisplay {
+            primary: None,
+            secondary: None,
+        };
+        bar.update_snapshot(Some(snapshot));
+        assert!(!bar.should_show());
+    }
+
+    #[test]
+    fn test_default_trait() {
+        let bar = UsageStatusBar::default();
+        assert!(!bar.is_dismissed());
+        assert!(bar.snapshot.is_none());
+    }
+
+    // Helper method tests
+    #[test]
+    fn test_significant_change_detection() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(70.0), None)));
+
+        let old = bar.snapshot.clone().unwrap();
+        let new = create_test_snapshot(Some(71.0), None);
+        assert!(!bar.has_significant_change(&old, &new));
+
+        let new = create_test_snapshot(Some(76.0), None);
+        assert!(bar.has_significant_change(&old, &new));
+    }
+
+    #[test]
+    fn test_max_percent_from_snapshot() {
+        let bar = UsageStatusBar::new();
+
+        let snapshot = create_test_snapshot(Some(80.0), Some(60.0));
+        assert_eq!(bar.max_percent_from_snapshot(&snapshot), Some(80.0));
+
+        let snapshot = create_test_snapshot(Some(60.0), Some(90.0));
+        assert_eq!(bar.max_percent_from_snapshot(&snapshot), Some(90.0));
+
+        let snapshot = create_test_snapshot(None, Some(75.0));
+        assert_eq!(bar.max_percent_from_snapshot(&snapshot), Some(75.0));
+
+        let snapshot = create_test_snapshot(None, None);
+        assert_eq!(bar.max_percent_from_snapshot(&snapshot), None);
+    }
+
+    #[test]
+    fn test_format_window_duration_with_value() {
+        let result = format_window_duration(Some(300), "default");
+        assert_eq!(result, "5h");
+    }
+
+    #[test]
+    fn test_format_window_duration_none() {
+        let result = format_window_duration(None, "weekly");
+        assert_eq!(result, "weekly");
+    }
+
+    #[test]
+    fn test_get_urgent_window_info_returns_none_when_below_threshold() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(50.0), Some(60.0))));
+        assert!(bar.get_urgent_window_info().is_none());
+    }
+
+    #[test]
+    fn test_get_urgent_window_info_contains_correct_fields() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(80.0), None)));
+
+        let info = bar.get_urgent_window_info().unwrap();
+        assert_eq!(info.percent, 80.0);
+        assert_eq!(info.reset_at, Some("in 30m".to_string()));
+        assert_eq!(info.window_label, "5h");
+    }
+
+    #[test]
+    fn test_get_footer_text_format() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(85.0), None)));
+
+        let text = bar.get_footer_text().unwrap();
+        assert_eq!(text.text, "85% of limit (resets in 30m)");
+        assert!(!text.at_limit);
+    }
+
+    #[test]
+    fn test_get_footer_text_weekly_format() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(None, Some(95.0))));
+
+        let text = bar.get_footer_text().unwrap();
+        assert_eq!(text.text, "95% of weekly limit (resets in 2h)");
+        assert!(!text.at_limit);
+    }
+
+    #[test]
+    fn test_get_footer_text_at_100_percent() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(100.0), None)));
+
+        let text = bar.get_footer_text().unwrap();
+        assert_eq!(text.text, "limit reached (resets in 30m)");
+        assert!(text.at_limit);
+    }
+
+    #[test]
+    fn test_get_footer_text_above_100_percent() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(120.0), None)));
+
+        let text = bar.get_footer_text().unwrap();
+        assert_eq!(text.text, "limit reached (resets in 30m)");
+        assert!(text.at_limit);
+    }
+
+    #[test]
+    fn test_get_footer_text_weekly_at_100_percent() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(None, Some(100.0))));
+
+        let text = bar.get_footer_text().unwrap();
+        assert_eq!(text.text, "weekly limit reached (resets in 2h)");
+        assert!(text.at_limit);
+    }
+
+    #[test]
+    fn test_dismiss_clears_footer_text() {
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(85.0), None)));
+
+        // Verify banner is shown
+        assert!(bar.should_show());
+        assert!(bar.get_footer_text().is_some());
+
+        // Dismiss the banner
+        bar.dismiss();
+
+        // Verify banner is cleared
+        assert!(!bar.should_show());
+        assert!(bar.get_footer_text().is_none());
+    }
+
+    // Widget rendering tests
+    #[test]
+    fn test_widget_render_when_hidden() {
+        use ratatui::widgets::WidgetRef;
+
+        let bar = UsageStatusBar::new();
+        let mut buf = Buffer::empty(Rect::new(0, 0, 80, 1));
+        (&bar).render_ref(Rect::new(0, 0, 80, 1), &mut buf);
+
+        let rendered: String = buf
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(rendered.trim().is_empty() || rendered.chars().all(|c| c == ' '));
+    }
+
+    #[test]
+    fn test_widget_render_when_shown() {
+        use ratatui::widgets::WidgetRef;
+
+        let mut bar = UsageStatusBar::new();
+        bar.update_snapshot(Some(create_test_snapshot(Some(85.0), None)));
+
+        let mut buf = Buffer::empty(Rect::new(0, 0, 80, 1));
+        (&bar).render_ref(Rect::new(0, 0, 80, 1), &mut buf);
+
+        let rendered: String = buf
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+
+        assert!(rendered.contains("85%"));
+        assert!(rendered.contains("5h"));
+        assert!(rendered.contains("Press Esc"));
+    }
+}


### PR DESCRIPTION
- surface rate-limit warnings in both the footer and the dismissible banner
- thread usage status updates through chat widget/composer wiring
- update footer/status snapshots for the new messaging