### PR TITLE
feat: isolate project config state writes

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]

--- a/codex-rs/core/tests/suite/seatbelt.rs
+++ b/codex-rs/core/tests/suite/seatbelt.rs
@@ -19,12 +19,14 @@ struct TestScenario {
     repo_root: PathBuf,
     file_in_repo_root: PathBuf,
     file_in_dot_git_dir: PathBuf,
+    file_in_dot_codex_dir: PathBuf,
 }
 
 struct TestExpectations {
     file_outside_repo_is_writable: bool,
     file_in_repo_root_is_writable: bool,
     file_in_dot_git_dir_is_writable: bool,
+    file_in_dot_codex_dir_is_writable: bool,
 }
 
 impl TestScenario {
@@ -60,6 +62,15 @@ impl TestScenario {
             self.file_in_dot_git_dir.exists(),
             expectations.file_in_dot_git_dir_is_writable
         );
+
+        assert_eq!(
+            touch(&self.file_in_dot_codex_dir, policy).await,
+            expectations.file_in_dot_codex_dir_is_writable
+        );
+        assert_eq!(
+            self.file_in_dot_codex_dir.exists(),
+            expectations.file_in_dot_codex_dir_is_writable
+        );
     }
 }
 
@@ -89,6 +100,7 @@ async fn if_parent_of_repo_is_writable_then_dot_git_folder_is_writable() {
                 file_outside_repo_is_writable: true,
                 file_in_repo_root_is_writable: true,
                 file_in_dot_git_dir_is_writable: true,
+                file_in_dot_codex_dir_is_writable: true,
             },
         )
         .await;
@@ -115,6 +127,7 @@ async fn if_git_repo_is_writable_root_then_dot_git_folder_is_read_only() {
                 file_outside_repo_is_writable: false,
                 file_in_repo_root_is_writable: true,
                 file_in_dot_git_dir_is_writable: false,
+                file_in_dot_codex_dir_is_writable: false,
             },
         )
         .await;
@@ -135,6 +148,7 @@ async fn danger_full_access_allows_all_writes() {
                 file_outside_repo_is_writable: true,
                 file_in_repo_root_is_writable: true,
                 file_in_dot_git_dir_is_writable: true,
+                file_in_dot_codex_dir_is_writable: true,
             },
         )
         .await;
@@ -154,6 +168,7 @@ async fn read_only_forbids_all_writes() {
                 file_outside_repo_is_writable: false,
                 file_in_repo_root_is_writable: false,
                 file_in_dot_git_dir_is_writable: false,
+                file_in_dot_codex_dir_is_writable: false,
             },
         )
         .await;
@@ -208,9 +223,11 @@ fn create_test_scenario(tmp: &TempDir) -> TestScenario {
     let repo_parent = tmp.path().to_path_buf();
     let repo_root = repo_parent.join("repo");
     let dot_git_dir = repo_root.join(".git");
+    let dot_codex_dir = repo_root.join(".codex");
 
     std::fs::create_dir(&repo_root).expect("should be able to create repo root");
     std::fs::create_dir(&dot_git_dir).expect("should be able to create .git dir");
+    std::fs::create_dir(&dot_codex_dir).expect("should be able to create .codex dir");
 
     TestScenario {
         file_outside_repo: repo_parent.join("outside.txt"),
@@ -218,6 +235,7 @@ fn create_test_scenario(tmp: &TempDir) -> TestScenario {
         file_in_repo_root: repo_root.join("repo_file.txt"),
         repo_root,
         file_in_dot_git_dir: dot_git_dir.join("dot_git_file.txt"),
+        file_in_dot_codex_dir: dot_codex_dir.join("config.toml"),
     }
 }
 

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -372,10 +372,20 @@ impl SandboxPolicy {
                     .into_iter()
                     .map(|writable_root| {
                         let mut subpaths = Vec::new();
+
+                        // Keep .git directory read-only to prevent accidental modification
                         let top_level_git = writable_root.join(".git");
                         if top_level_git.is_dir() {
                             subpaths.push(top_level_git);
                         }
+
+                        // Keep .codex directory read-only to prevent accidental modification
+                        // of project configuration
+                        let top_level_codex = writable_root.join(".codex");
+                        if top_level_codex.is_dir() {
+                            subpaths.push(top_level_codex);
+                        }
+
                         WritableRoot {
                             root: writable_root,
                             read_only_subpaths: subpaths,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -16,6 +16,7 @@ use codex_ansi_escape::ansi_escape_line;
 use codex_core::AuthManager;
 use codex_core::ConversationManager;
 use codex_core::config::Config;
+use codex_core::config::find_state_directory;
 use codex_core::config::persist_model_selection;
 use codex_core::model_family::find_family_for_model;
 use codex_core::protocol::SessionSource;
@@ -329,9 +330,9 @@ impl App {
             }
             AppEvent::PersistModelSelection { model, effort } => {
                 let profile = self.active_profile.as_deref();
-                match persist_model_selection(&self.config.codex_home, profile, &model, effort)
-                    .await
-                {
+                let state_dir =
+                    find_state_directory().unwrap_or_else(|_| self.config.codex_home.clone());
+                match persist_model_selection(&state_dir, profile, &model, effort).await {
                     Ok(()) => {
                         let effort_label = effort
                             .map(|eff| format!(" with {eff} reasoning"))

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use codex_core::config::find_state_directory;
 use codex_core::config::set_project_trusted;
 use codex_core::git_info::resolve_root_git_project_for_trust;
 use crossterm::event::KeyCode;
@@ -145,7 +146,8 @@ impl TrustDirectoryWidget {
     fn handle_trust(&mut self) {
         let target =
             resolve_root_git_project_for_trust(&self.cwd).unwrap_or_else(|| self.cwd.clone());
-        if let Err(e) = set_project_trusted(&self.codex_home, &target) {
+        let state_dir = find_state_directory().unwrap_or_else(|_| self.codex_home.clone());
+        if let Err(e) = set_project_trusted(&state_dir, &target) {
             tracing::error!("Failed to set project trusted: {e:?}");
             self.error = Some(format!("Failed to set trust for {}: {e}", target.display()));
         }

--- a/codex-rs/tui/src/onboarding/windows.rs
+++ b/codex-rs/tui/src/onboarding/windows.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use codex_core::config::find_state_directory;
 use codex_core::config::set_windows_wsl_setup_acknowledged;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -54,7 +55,8 @@ impl WindowsSetupWidget {
 
     fn handle_continue(&mut self) {
         self.highlighted = WindowsSetupSelection::Continue;
-        match set_windows_wsl_setup_acknowledged(&self.codex_home, true) {
+        let state_dir = find_state_directory().unwrap_or_else(|_| self.codex_home.clone());
+        match set_windows_wsl_setup_acknowledged(&state_dir, true) {
             Ok(()) => {
                 self.selection = Some(WindowsSetupSelection::Continue);
                 self.exit_requested = false;


### PR DESCRIPTION
## Summary
- route config writes to the global state dir while leaving project `.codex` read-only
- safeguard sandboxes from touching `.codex` and cover it with unit tests
- update CLI/TUI flows to persist settings via the new state helpers

## Testing
- skipped (per request)
