### PR TITLE
fix(tui): fix copy-paste experience, also allow webp & urls

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3185,12 +3185,23 @@ checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
  "tiff",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -45,7 +45,7 @@ crossterm = { workspace = true, features = ["bracketed-paste", "event-stream"] }
 diffy = { workspace = true }
 dirs = { workspace = true }
 dunce = { workspace = true }
-image = { workspace = true, features = ["jpeg", "png"] }
+image = { workspace = true, features = ["jpeg", "png", "webp"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 mcp-types = { workspace = true }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -46,6 +46,7 @@ pub(crate) enum CancellationEvent {
 }
 
 pub(crate) use chat_composer::ChatComposer;
+pub(crate) use chat_composer::ComposerAttachment;
 pub(crate) use chat_composer::InputResult;
 use codex_protocol::custom_prompts::CustomPrompt;
 
@@ -463,7 +464,25 @@ impl BottomPane {
         }
     }
 
-    pub(crate) fn take_recent_submission_images(&mut self) -> Vec<PathBuf> {
+    pub(crate) fn attach_image_from_path(&mut self, path: PathBuf) -> bool {
+        if self.view_stack.is_empty() {
+            match self.composer.attach_image_from_path(path) {
+                Ok(()) => {
+                    self.composer.insert_str(" ");
+                    self.request_redraw();
+                    true
+                }
+                Err(err) => {
+                    tracing::info!("failed to attach clipboard path: {err}");
+                    false
+                }
+            }
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn take_recent_submission_images(&mut self) -> Vec<ComposerAttachment> {
         self.composer.take_recent_submission_images()
     }
 


### PR DESCRIPTION
There were bugs that were preventing copy-pasting images from working. 

This also adds support to copy-paste images from:
* Remote URLs (note: client does _not_ download the image; uses Responses API)
* Allows `.webp` images (note: enables "webp" feature on `image` crate)

---

### Before

<img width="708" height="369" alt="Screenshot 2025-11-07 at 5 07 00 PM" src="https://github.com/user-attachments/assets/4eb78f2f-f2a9-4008-a62c-b3d6357030ec" />

---

### After

1. https://github.com/user-attachments/assets/0043f9ad-eac8-459f-9ebf-95f77a32f679

2. https://github.com/user-attachments/assets/be947918-8bda-439a-bf5b-10ab38b1e60c

3. https://github.com/user-attachments/assets/2ecf0afa-5951-43f8-9ec0-9530292db39b

---

### Issues

```js
* https://github.com/openai/codex/issues/6080
* https://github.com/openai/codex/issues/3397
* https://github.com/openai/codex/issues/4366
```